### PR TITLE
Ensure Xaml shuts down on each thread when MultiWindowXamlApp window is destroyed

### DIFF
--- a/MultiWindow/MultiWindowXamlApp.vcxproj
+++ b/MultiWindow/MultiWindowXamlApp.vcxproj
@@ -8,7 +8,7 @@
     <RootNamespace>MultiWindowXamlApp</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
This change closes the WindowsXamlManager object when each MultiWindowXamlApp window is destroyed.  This triggers Xaml to run down and clean up on that thread during the message loop.

It also avoids a Xaml crash by manually creating a Xaml Application object before using Xaml in the process.